### PR TITLE
HOFF-1851: Update the HOF country list to show Palestine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+## 2025-10-08, Version 0.2.0, @Rhodine-orleans-lindsay
+### Changed
+* Updated country list
+
 ## 2016-12-08, Version 0.1.0, @josephchapman
 * First release

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ var countriesNonEU = [
   'Oman',
   'Pakistan',
   'Palau',
-  'Palestinian Authority',
+  'Palestine',
   'Panama',
   'Papua New Guinea',
   'Paraguay',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeoffice-countries",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Exports a list of countries that can, for example, be used with Typeahead Aria",
   "license": "GPLv3",
   "author": "UKHomeOffice",

--- a/pull-request-template.md
+++ b/pull-request-template.md
@@ -1,0 +1,14 @@
+## What?
+## Why?
+## How?
+## Testing?
+## Screenshots (optional)
+## Anything Else? (optional)
+## Check list
+
+- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
+- [ ] I have created a JIRA number for my branch
+- [ ] I have created a JIRA number for my commit
+- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
+here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
+- [ ] I will squash the commits before merging


### PR DESCRIPTION
## What?
- Update the HOF country list - [HOFF-1851](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1851)
## Why?
- List must be updated following changes to state recognition
## How?
- Changed 'Palestinan Authority' to 'Palestine' in index.js
## Testing?
- will be tested via hof beta package
## Screenshots (optional)
## Anything Else? (optional)
- added pr template
-  other amendements are required to the country list e.g. changes to other country names, removal of countriesDomestic from euCountries following UK exit from the EU, etc but these will be addressed in another ticket.
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] I will squash the commits before merging
